### PR TITLE
feat: no longer respond to address claim message when name is the same

### DIFF
--- a/j1939/controller_application.py
+++ b/j1939/controller_application.py
@@ -190,6 +190,10 @@ class ControllerApplication:
 
             contenders_name = j1939.Name(bytes = data)
 
+            if self._name.value == contenders_name.value:
+                # both have the same name - this could mean that we are the device or there is a duplicate
+                return
+            
             if self._name.value > contenders_name.value:
                 # we have to release our address and claim another one
                 logger.info("We have to release our address '%d' because the contenders name is less than ours", src_address)

--- a/test/test_ca.py
+++ b/test/test_ca.py
@@ -62,6 +62,18 @@ def test_addr_claim_fixed_veto_lose(feeder):
 
     address_claim(feeder, expected_state=j1939.ControllerApplication.State.CANNOT_CLAIM)
 
+def test_addr_claim_fixed_duplicate_response(feeder):
+    """Test CA Address claim on the bus and a duplicate response is received from a device with 
+    the same name
+    """
+    feeder.can_messages = [
+        (Feeder.MsgType.CANTX, 0x18EEFF80, [135, 214, 82, 83, 130, 201, 254, 82], 0.0),    # Address Claimed
+        (Feeder.MsgType.CANRX, 0x18EEFF80, [135, 214, 82, 83, 130, 201, 254, 82], 0.0),    # Response from Counterpart with same name
+    ]
+
+    address_claim(feeder)
+
+
 def test_addr_claim_fixed_veto_win(feeder):
     """Test CA Address claim on the bus with fixed address and a veto counterpart
     This test runs a "Single Address Capable" claim procedure with a fixed


### PR DESCRIPTION
I noticed when I was doing more testing with this when running on a socketcan environment that I was receiving my own address claim messages when I'd send them out so added this filter to stop doing that